### PR TITLE
fix: 修复弃用警告

### DIFF
--- a/nonebot_plugin_chatrecorder/migrations/2cad88d938f1_init_db.py
+++ b/nonebot_plugin_chatrecorder/migrations/2cad88d938f1_init_db.py
@@ -17,9 +17,9 @@ depends_on = None
 
 
 def _has_table(name: str) -> bool:
-    from sqlalchemy.engine.reflection import Inspector
+    from sqlalchemy import inspect
 
-    insp = Inspector.from_engine(op.get_bind())
+    insp = inspect(op.get_bind())
     return name in insp.get_table_names()
 
 


### PR DESCRIPTION
>SADeprecationWarning: The from_engine() method on Inspector is deprecated and will be removed in a future release.  Please use the sqlalchemy.inspect() function on an Engine or Connection in order to acquire an Inspector. (deprecated since: 1.4)

copilot 给的代码，还是不够靠谱啊（