### PR TITLE
修复在 sqlite 迁移时的报错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .vscode/
 .coverage
 data/
+.env

--- a/nonebot_plugin_chatrecorder/migrations/902a51ac4032_add_session.py
+++ b/nonebot_plugin_chatrecorder/migrations/902a51ac4032_add_session.py
@@ -78,14 +78,15 @@ def upgrade() -> None:
                 session_key_id_map[session_key] = session_obj.id
 
             # 更新新插入的 session
-            for session_obj in session.scalars(
-                insert(SessionModel).returning(SessionModel),
+            session.execute(
+                insert(SessionModel),
                 [
                     session_dict
                     for key, session_dict in bulk_insert_sessions.items()
                     if key not in session_key_id_map  # 去重
                 ],
-            ).all():
+            )
+            for session_obj in session.scalars(select(SessionModel)).all():
                 session_key = (
                     session_obj.bot_id,
                     session_obj.bot_type,


### PR DESCRIPTION
> excutemary is not supported with RETURNIMG

所以直接删掉，不使用 returning 了。不过也许可以根据不同数据库做不同处理？

有点想把迁移脚本的测试弄出来了。