### PR TITLE
adjust tests

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -15,7 +15,7 @@ def fake_message_event(**field) -> MessageEvent:
 
     class FakeEvent(_Fake):
         time: datetime = datetime.fromtimestamp(1000000, timezone.utc)
-        self_id: str = "console"
+        self_id: str = "Bot"
         post_type: str = "message"
         user: User = User(id="User")
         message: Message = Message("test")
@@ -32,8 +32,8 @@ async def test_record_recv_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
-        bot = ctx.create_bot(base=Bot, adapter=Adapter(get_driver()), self_id="console")
-    assert isinstance(bot, Bot)
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="Bot")
 
     time = 1000000
     user_id = "User"
@@ -45,7 +45,7 @@ async def test_record_recv_msg(app: App):
     )
     await record_recv_msg(bot, event)
     await check_record(
-        "console",
+        "Bot",
         "Console",
         "console",
         1,
@@ -66,8 +66,8 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
-        bot = ctx.create_bot(base=Bot, adapter=Adapter(get_driver()), self_id="console")
-    assert isinstance(bot, Bot)
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="Bot")
 
     user_id = "User"
     elements = ConsoleMessage([Text("test_record_send_msg")])
@@ -76,7 +76,7 @@ async def test_record_send_msg(app: App):
         bot, None, "send_msg", {"user_id": user_id, "message": elements}, None
     )
     await check_record(
-        "console",
+        "Bot",
         "Console",
         "console",
         1,

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -28,22 +28,23 @@ def fake_message_event(**field) -> MessageEvent:
 
 async def test_record_recv_msg(app: App):
     # 测试记录收到的消息
-    from nonebot_plugin_chatrecorder.adapters.console import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        adapter = get_driver()._adapters[Adapter.get_name()]
-        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="Bot")
 
     time = 1000000
     user_id = "User"
     message = Message("test_record_recv_msg")
-    event = fake_message_event(
-        time=datetime.fromtimestamp(time, timezone.utc),
-        user=User(id=user_id),
-        message=message,
-    )
-    await record_recv_msg(bot, event)
+
+    async with app.test_matcher() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="Bot")
+
+        event = fake_message_event(
+            time=datetime.fromtimestamp(time, timezone.utc),
+            user=User(id=user_id),
+            message=message,
+        )
+        ctx.receive_event(bot, event)
+
     await check_record(
         "Bot",
         "Console",

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -95,19 +95,26 @@ def fake_direct_message_event(content: str, msg_id: int) -> DirectMessageCreateE
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.discord import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    guild_msg = "test guild message"
+    guild_msg_id = 11234
+
+    direct_msg = "test direct message"
+    direct_msg_id = 11235
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot, adapter=adapter, self_id="2233", bot_info=BotInfo(token="1234")
         )
 
-    content = "test guild message"
-    msg_id = 11234
-    event = fake_guild_message_event(content, msg_id)
-    await record_recv_msg(bot, event)
+        event = fake_guild_message_event(guild_msg, guild_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_direct_message_event(direct_msg, direct_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "Discord",
@@ -118,15 +125,11 @@ async def test_record_recv_msg(app: App):
         "6677",
         datetime.fromtimestamp(123456, timezone.utc),
         "message",
-        "11234",
-        serialize_message(bot, Message(content)),
-        Message(content).extract_plain_text(),
+        str(guild_msg_id),
+        serialize_message(bot, Message(guild_msg)),
+        guild_msg,
     )
 
-    content = "test direct message"
-    msg_id = 11235
-    event = fake_direct_message_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "Discord",
@@ -137,9 +140,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(123456, timezone.utc),
         "message",
-        "11235",
-        serialize_message(bot, Message(content)),
-        Message(content).extract_plain_text(),
+        str(direct_msg_id),
+        serialize_message(bot, Message(direct_msg)),
+        direct_msg,
     )
 
 

--- a/tests/test_discord.py
+++ b/tests/test_discord.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from nonebot import get_driver
 from nonebot.adapters.discord import (
+    Adapter,
     Bot,
     DirectMessageCreateEvent,
     GuildMessageCreateEvent,
@@ -21,25 +22,11 @@ from nonebug.app import App
 from .utils import check_record
 
 
-async def test_record_recv_msg(app: App):
-    """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.discord import record_recv_msg
-    from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        bot = ctx.create_bot(
-            base=Bot,
-            adapter=get_driver()._adapters["Discord"],
-            self_id="2233",
-            bot_info=BotInfo(token="1234"),
-        )
-    assert isinstance(bot, Bot)
-
-    content = "test guild message"
-    event = type_validate_python(
+def fake_guild_message_event(content: str, msg_id: int) -> GuildMessageCreateEvent:
+    return type_validate_python(
         GuildMessageCreateEvent,
         {
-            "id": 11234,
+            "id": msg_id,
             "channel_id": 5566,
             "guild_id": 6677,
             "author": User(
@@ -69,32 +56,18 @@ async def test_record_recv_msg(app: App):
             "reply": None,
         },
     )
-    await record_recv_msg(bot, event)
-    await check_record(
-        "2233",
-        "Discord",
-        "discord",
-        3,
-        "3344",
-        "5566",
-        "6677",
-        datetime.fromtimestamp(123456, timezone.utc),
-        "message",
-        "11234",
-        serialize_message(bot, Message(content)),
-        Message(content).extract_plain_text(),
-    )
 
-    content = "test direct message"
-    event = type_validate_python(
+
+def fake_direct_message_event(content: str, msg_id: int) -> DirectMessageCreateEvent:
+    return type_validate_python(
         DirectMessageCreateEvent,
         {
-            "id": 11235,
+            "id": msg_id,
             "channel_id": 5566,
             "author": User(
                 **{
                     "id": 3344,
-                    "username": "bot",
+                    "username": "MyUser",
                     "discriminator": "0",
                     "avatar": "xxx",
                 }
@@ -118,6 +91,41 @@ async def test_record_recv_msg(app: App):
             "reply": None,
         },
     )
+
+
+async def test_record_recv_msg(app: App):
+    """测试记录收到的消息"""
+    from nonebot_plugin_chatrecorder.adapters.discord import record_recv_msg
+    from nonebot_plugin_chatrecorder.message import serialize_message
+
+    async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="2233", bot_info=BotInfo(token="1234")
+        )
+
+    content = "test guild message"
+    msg_id = 11234
+    event = fake_guild_message_event(content, msg_id)
+    await record_recv_msg(bot, event)
+    await check_record(
+        "2233",
+        "Discord",
+        "discord",
+        3,
+        "3344",
+        "5566",
+        "6677",
+        datetime.fromtimestamp(123456, timezone.utc),
+        "message",
+        "11234",
+        serialize_message(bot, Message(content)),
+        Message(content).extract_plain_text(),
+    )
+
+    content = "test direct message"
+    msg_id = 11235
+    event = fake_direct_message_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -141,13 +149,10 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
-            base=Bot,
-            adapter=get_driver()._adapters["Discord"],
-            self_id="2233",
-            bot_info=BotInfo(token="1234"),
+            base=Bot, adapter=adapter, self_id="2233", bot_info=BotInfo(token="1234")
         )
-        assert isinstance(bot, Bot)
 
         content = "test create guild message"
         ctx.should_call_api(

--- a/tests/test_dodo.py
+++ b/tests/test_dodo.py
@@ -63,10 +63,15 @@ def fake_personal_message_event(content: str, message_id: str) -> PersonalMessag
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.dodo import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    channel_msg = "test channel message"
+    channel_msg_id = "123456"
+
+    personal_msg = "test personal message"
+    personal_msg_id = "123457"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
@@ -75,10 +80,12 @@ async def test_record_recv_msg(app: App):
             bot_config=BotConfig(client_id="1234", token="xxxx"),
         )
 
-    content = "test channel message"
-    message_id = "123456"
-    event = fake_channel_message_event(content, message_id)
-    await record_recv_msg(bot, event)
+        event = fake_channel_message_event(channel_msg, channel_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_personal_message_event(personal_msg, personal_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "DoDo",
@@ -89,15 +96,11 @@ async def test_record_recv_msg(app: App):
         "7788",
         datetime.fromtimestamp(12345678, timezone.utc),
         "message",
-        message_id,
-        serialize_message(bot, Message(content)),
-        content,
+        channel_msg_id,
+        serialize_message(bot, Message(channel_msg)),
+        channel_msg,
     )
 
-    content = "test personal message"
-    message_id = "123457"
-    event = fake_personal_message_event(content, message_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "DoDo",
@@ -108,9 +111,9 @@ async def test_record_recv_msg(app: App):
         "7788",
         datetime.fromtimestamp(12345678, timezone.utc),
         "message",
-        message_id,
-        serialize_message(bot, Message(content)),
-        content,
+        personal_msg_id,
+        serialize_message(bot, Message(personal_msg)),
+        personal_msg,
     )
 
 

--- a/tests/test_fake_event.py
+++ b/tests/test_fake_event.py
@@ -43,8 +43,8 @@ async def test_record_recv_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
-        bot = ctx.create_bot(base=Bot, adapter=Adapter(get_driver()), self_id="11")
-    assert isinstance(bot, Bot)
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
 
     time = 1000000
     user_id = 123456

--- a/tests/test_fake_event.py
+++ b/tests/test_fake_event.py
@@ -39,22 +39,22 @@ def fake_private_message_event(**field) -> PrivateMessageEvent:
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.onebot_v11 import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        adapter = get_driver()._adapters[Adapter.get_name()]
-        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
 
     time = 1000000
     user_id = 123456
-
     message_id = 1145141919810
     message = Message("test private message")
-    event = fake_private_message_event(
-        time=time, user_id=user_id, message_id=message_id, message=message
-    )
-    await record_recv_msg(bot, event)
+
+    async with app.test_matcher() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
+
+        event = fake_private_message_event(
+            time=time, user_id=user_id, message_id=message_id, message=message
+        )
+        ctx.receive_event(bot, event)
+
     await check_record(
         "11",
         "OneBot V11",

--- a/tests/test_get_records.py
+++ b/tests/test_get_records.py
@@ -26,9 +26,9 @@ async def test_get_message_records(app: App):
     )
 
     async with app.test_api() as ctx:
-        v11_adapter = V11Adapter(get_driver())
+        v11_adapter = get_driver()._adapters[V11Adapter.get_name()]
         v11_bot = ctx.create_bot(base=V11Bot, adapter=v11_adapter, self_id="11")
-        v12_adapter = V12Adapter(get_driver())
+        v12_adapter = get_driver()._adapters[V12Adapter.get_name()]
         v12_bot = ctx.create_bot(
             base=V12Bot,
             adapter=v12_adapter,
@@ -36,8 +36,6 @@ async def test_get_message_records(app: App):
             platform="qq",
             impl="walle-q",
         )
-    assert isinstance(v11_bot, V11Bot)
-    assert isinstance(v12_bot, V12Bot)
 
     sessions = [
         Session(

--- a/tests/test_kaiheila.py
+++ b/tests/test_kaiheila.py
@@ -88,19 +88,26 @@ def fake_channel_message_event(content: str, msg_id: str) -> ChannelMessageEvent
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.kaiheila import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    private_msg = "test private message"
+    private_msg_id = "4455"
+
+    channel_msg = "test channel message"
+    channel_msg_id = "4456"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot, adapter=adapter, self_id="2233", name="Bot", token=""
         )
 
-    content = "test private message"
-    msg_id = "4455"
-    event = fake_private_message_event(content, msg_id)
-    await record_recv_msg(bot, event)
+        event = fake_private_message_event(private_msg, private_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_channel_message_event(channel_msg, channel_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "Kaiheila",
@@ -111,15 +118,11 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(1234000 / 1000, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        private_msg_id,
+        serialize_message(bot, Message(private_msg)),
+        private_msg,
     )
 
-    content = "test channel message"
-    msg_id = "4456"
-    event = fake_channel_message_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "Kaiheila",
@@ -130,9 +133,9 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime.fromtimestamp(1234000 / 1000, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        channel_msg_id,
+        serialize_message(bot, Message(channel_msg)),
+        channel_msg,
     )
 
 

--- a/tests/test_kaiheila.py
+++ b/tests/test_kaiheila.py
@@ -11,9 +11,79 @@ from nonebot.adapters.kaiheila.event import (
     PrivateMessageEvent,
     User,
 )
+from nonebot.compat import type_validate_python
 from nonebug.app import App
 
 from .utils import check_record
+
+
+def fake_private_message_event(content: str, msg_id: str) -> PrivateMessageEvent:
+    return type_validate_python(
+        PrivateMessageEvent,
+        {
+            "post_type": "message",
+            "channel_type": "PERSON",
+            "type": 1,
+            "target_id": "6677",
+            "author_id": "3344",
+            "content": content,
+            "msg_id": msg_id,
+            "msg_timestamp": 1234000,
+            "nonce": "",
+            "extra": Extra(type=1),  # type: ignore
+            "user_id": "3344",
+            "self_id": "2233",
+            "message_type": "private",
+            "sub_type": "",
+            "event": EventMessage(
+                type=1,
+                content="test private message",  # type: ignore
+                author=User(id="3344"),
+                kmarkdown={
+                    "raw_content": content,
+                    "mention_part": [],
+                    "mention_role_part": [],
+                },  # type: ignore
+            ),
+        },
+    )
+
+
+def fake_channel_message_event(content: str, msg_id: str) -> ChannelMessageEvent:
+    return type_validate_python(
+        ChannelMessageEvent,
+        {
+            "post_type": "message",
+            "channel_type": "GROUP",
+            "type": 1,
+            "target_id": "6677",
+            "author_id": "3344",
+            "content": content,
+            "msg_id": msg_id,
+            "msg_timestamp": 1234000,
+            "nonce": "",
+            "extra": Extra(
+                type=1,
+                guild_id="5566",
+            ),  # type: ignore
+            "user_id": "3344",
+            "self_id": "2233",
+            "group_id": "6677",
+            "message_type": "group",
+            "sub_type": "",
+            "event": EventMessage(
+                type=1,
+                guild_id="5566",
+                content="test channel message",  # type: ignore
+                author=User(id="3344"),
+                kmarkdown={
+                    "raw_content": content,
+                    "mention_part": [],
+                    "mention_role_part": [],
+                },  # type: ignore
+            ),
+        },
+    )
 
 
 async def test_record_recv_msg(app: App):
@@ -22,57 +92,14 @@ async def test_record_recv_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
-            base=Bot,
-            adapter=Adapter(get_driver()),
-            self_id="2233",
-            name="Bot",
-            token="",
+            base=Bot, adapter=adapter, self_id="2233", name="Bot", token=""
         )
 
-    event = PrivateMessageEvent(
-        post_type="message",
-        channel_type="PERSON",
-        type=1,
-        target_id="6677",
-        author_id="3344",
-        content="123",
-        msg_id="4455",
-        msg_timestamp=1234000,
-        nonce="",
-        extra=Extra(
-            type=1,
-            guild_id=None,
-            channel_name=None,
-            mention=[],
-            mention_all=False,
-            mention_roles=[],
-            mention_here=False,
-            author=None,
-            body=None,
-            attachments=None,
-            code=None,
-        ),
-        user_id="3344",
-        self_id="2233",
-        message_type="private",
-        sub_type="",
-        event=EventMessage(
-            type=1,
-            guild_id=None,
-            channel_name=None,
-            content="test private message",  # type: ignore
-            mention=[],
-            mention_all=False,
-            mention_roles=[],
-            mention_here=False,
-            nav_channels=[],
-            author=User(id="3344"),
-            kmarkdown=None,
-            attachments=None,
-            code=None,
-        ),
-    )
+    content = "test private message"
+    msg_id = "4455"
+    event = fake_private_message_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -84,55 +111,14 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(1234000 / 1000, timezone.utc),
         "message",
-        "4455",
-        serialize_message(bot, Message("test private message")),
-        "test private message",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
-    event = ChannelMessageEvent(
-        post_type="message",
-        channel_type="GROUP",
-        type=9,
-        target_id="6677",
-        author_id="3344",
-        content="123",
-        msg_id="4456",
-        msg_timestamp=1234000,
-        nonce="",
-        extra=Extra(
-            type=1,
-            guild_id="5566",
-            channel_name="test",
-            mention=[],
-            mention_all=False,
-            mention_roles=[],
-            mention_here=False,
-            author=None,
-            body=None,
-            attachments=None,
-            code=None,
-        ),
-        user_id="3344",
-        self_id="2233",
-        group_id="6677",
-        message_type="group",
-        sub_type="",
-        event=EventMessage(
-            type=1,
-            guild_id="5566",
-            channel_name="test",
-            content="test channel message",  # type: ignore
-            mention=[],
-            mention_all=False,
-            mention_roles=[],
-            mention_here=False,
-            nav_channels=[],
-            author=User(id="3344"),
-            kmarkdown=None,
-            attachments=None,
-            code=None,
-        ),
-    )
+    content = "test channel message"
+    msg_id = "4456"
+    event = fake_channel_message_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -144,9 +130,9 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime.fromtimestamp(1234000 / 1000, timezone.utc),
         "message",
-        "4456",
-        serialize_message(bot, Message("test channel message")),
-        "test channel message",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
 
@@ -156,12 +142,9 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
-            base=Bot,
-            adapter=Adapter(get_driver()),
-            self_id="2233",
-            name="Bot",
-            token="",
+            base=Bot, adapter=adapter, self_id="2233", name="Bot", token=""
         )
 
     await record_send_msg(

--- a/tests/test_onebot_v11.py
+++ b/tests/test_onebot_v11.py
@@ -75,8 +75,8 @@ async def test_record_recv_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
-        bot = ctx.create_bot(base=Bot, adapter=Adapter(get_driver()), self_id="11")
-    assert isinstance(bot, Bot)
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
 
     time = 1000000
     user_id = 123456
@@ -134,8 +134,8 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
-        bot = ctx.create_bot(base=Bot, adapter=Adapter(get_driver()), self_id="11")
-    assert isinstance(bot, Bot)
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
 
     user_id = 123456
     group_id = 654321

--- a/tests/test_onebot_v12.py
+++ b/tests/test_onebot_v12.py
@@ -95,14 +95,10 @@ async def test_record_recv_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
-            base=Bot,
-            adapter=Adapter(get_driver()),
-            self_id="12",
-            platform="qq",
-            impl="walle-q",
+            base=Bot, adapter=adapter, self_id="12", platform="qq", impl="walle-q"
         )
-    assert isinstance(bot, Bot)
 
     time = datetime.fromtimestamp(1000000, timezone.utc)
     user_id = "111111"
@@ -189,14 +185,10 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
-            base=Bot,
-            adapter=Adapter(get_driver()),
-            self_id="12",
-            platform="qq",
-            impl="walle-q",
+            base=Bot, adapter=adapter, self_id="12", platform="qq", impl="walle-q"
         )
-    assert isinstance(bot, Bot)
 
     time = 1000000
     user_id = "111111"

--- a/tests/test_onebot_v12.py
+++ b/tests/test_onebot_v12.py
@@ -91,14 +91,7 @@ def fake_channel_message_event_v12(**field) -> ChannelMessageEvent:
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.onebot_v12 import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        adapter = get_driver()._adapters[Adapter.get_name()]
-        bot = ctx.create_bot(
-            base=Bot, adapter=adapter, self_id="12", platform="qq", impl="walle-q"
-        )
 
     time = datetime.fromtimestamp(1000000, timezone.utc)
     user_id = "111111"
@@ -106,16 +99,45 @@ async def test_record_recv_msg(app: App):
     guild_id = "333333"
     channel_id = "444444"
 
-    message_id = "11451411111"
-    message = Message("test group message")
-    event = fake_group_message_event(
-        time=time,
-        user_id=user_id,
-        group_id=group_id,
-        message_id=message_id,
-        message=message,
-    )
-    await record_recv_msg(bot, event)
+    group_msg = Message("test group message")
+    group_msg_id = "11451411111"
+
+    private_msg = Message("test private message")
+    private_msg_id = "11451422222"
+
+    channel_msg = Message("test channel message")
+    channel_msg_id = "11451433333"
+
+    async with app.test_matcher() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="12", platform="qq", impl="walle-q"
+        )
+
+        event = fake_group_message_event(
+            time=time,
+            user_id=user_id,
+            group_id=group_id,
+            message_id=group_msg_id,
+            message=group_msg,
+        )
+        ctx.receive_event(bot, event)
+
+        event = fake_private_message_event(
+            time=time, user_id=user_id, message_id=private_msg_id, message=private_msg
+        )
+        ctx.receive_event(bot, event)
+
+        event = fake_channel_message_event_v12(
+            time=time,
+            user_id=user_id,
+            guild_id=guild_id,
+            channel_id=channel_id,
+            message_id=channel_msg_id,
+            message=channel_msg,
+        )
+        ctx.receive_event(bot, event)
+
     await check_record(
         "12",
         "OneBot V12",
@@ -126,17 +148,11 @@ async def test_record_recv_msg(app: App):
         None,
         time,
         "message",
-        str(message_id),
-        serialize_message(bot, message),
-        message.extract_plain_text(),
+        str(group_msg_id),
+        serialize_message(bot, group_msg),
+        group_msg.extract_plain_text(),
     )
 
-    message_id = "11451422222"
-    message = Message("test private message")
-    event = fake_private_message_event(
-        time=time, user_id=user_id, message_id=message_id, message=message
-    )
-    await record_recv_msg(bot, event)
     await check_record(
         "12",
         "OneBot V12",
@@ -147,22 +163,11 @@ async def test_record_recv_msg(app: App):
         None,
         time,
         "message",
-        str(message_id),
-        serialize_message(bot, message),
-        message.extract_plain_text(),
+        str(private_msg_id),
+        serialize_message(bot, private_msg),
+        private_msg.extract_plain_text(),
     )
 
-    message_id = "11451433333"
-    message = Message("test channel message")
-    event = fake_channel_message_event_v12(
-        time=time,
-        user_id=user_id,
-        guild_id=guild_id,
-        channel_id=channel_id,
-        message_id=message_id,
-        message=message,
-    )
-    await record_recv_msg(bot, event)
     await check_record(
         "12",
         "OneBot V12",
@@ -173,9 +178,9 @@ async def test_record_recv_msg(app: App):
         str(guild_id),
         time,
         "message",
-        str(message_id),
-        serialize_message(bot, message),
-        message.extract_plain_text(),
+        str(channel_msg_id),
+        serialize_message(bot, channel_msg),
+        channel_msg.extract_plain_text(),
     )
 
 

--- a/tests/test_qq.py
+++ b/tests/test_qq.py
@@ -23,30 +23,76 @@ from nonebug import App
 from .utils import check_record
 
 
-async def test_record_recv_msg(app: App):
-    """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.qq import record_recv_msg
-    from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        bot = ctx.create_bot(
-            base=Bot,
-            adapter=Adapter(get_driver()),
-            self_id="2233",
-            bot_info=BotInfo(id="2233", token="", secret=""),
-        )
-
-    event = MessageCreateEvent(
+def fake_message_create_event(content: str, id: str) -> MessageCreateEvent:
+    return MessageCreateEvent(
         __type__=EventType.MESSAGE_CREATE,
-        id="1234",
+        id=id,
         timestamp=datetime(
             2023, 7, 30, 8, 0, 0, 0, tzinfo=timezone(timedelta(hours=8))
         ),
         channel_id="6677",
         guild_id="5566",
         author=User(id="3344"),
-        content="test message create event",
+        content=content,
     )
+
+
+def fake_direct_message_create_event(content: str, id: str) -> DirectMessageCreateEvent:
+    return DirectMessageCreateEvent(
+        __type__=EventType.DIRECT_MESSAGE_CREATE,
+        id=id,
+        timestamp=datetime(
+            2023, 7, 30, 8, 0, 0, 0, tzinfo=timezone(timedelta(hours=8))
+        ),
+        channel_id="6677",
+        guild_id="5566",
+        author=User(id="3344"),
+        content=content,
+    )
+
+
+def fake_group_at_message_create_event(
+    content: str, id: str
+) -> GroupAtMessageCreateEvent:
+    return GroupAtMessageCreateEvent(
+        __type__=EventType.GROUP_AT_MESSAGE_CREATE,
+        id=id,
+        timestamp="2023-11-06T13:37:18+08:00",
+        group_openid="195747FDF0D845E98CF3886C5C7ED328",
+        author=GroupMemberAuthor(
+            id="3344", member_openid="8BE608110EAA4328A1883DEF239F5580"
+        ),
+        content=content,
+    )
+
+
+def fake_c2c_message_create_event(content: str, id: str) -> C2CMessageCreateEvent:
+    return C2CMessageCreateEvent(
+        __type__=EventType.C2C_MESSAGE_CREATE,
+        id=id,
+        timestamp="2023-11-06T13:37:18+08:00",
+        author=FriendAuthor(id="3344", user_openid="451368C569A1401D87172E9435EE8663"),
+        content=content,
+    )
+
+
+async def test_record_recv_msg(app: App):
+    """测试记录收到的消息"""
+    from nonebot_plugin_chatrecorder.adapters.qq import record_recv_msg
+    from nonebot_plugin_chatrecorder.message import serialize_message
+
+    async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(
+            base=Bot,
+            adapter=adapter,
+            self_id="2233",
+            bot_info=BotInfo(id="2233", token="", secret=""),
+        )
+
+    content = "test message create event"
+    msg_id = "1234"
+    event = fake_message_create_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -58,22 +104,14 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime(2023, 7, 30, 0, 0, 0, 0, tzinfo=timezone.utc),
         "message",
-        "1234",
-        serialize_message(bot, Message("test message create event")),
-        "test message create event",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
-    event = DirectMessageCreateEvent(
-        __type__=EventType.DIRECT_MESSAGE_CREATE,
-        id="1235",
-        timestamp=datetime(
-            2023, 7, 30, 8, 0, 0, 0, tzinfo=timezone(timedelta(hours=8))
-        ),
-        channel_id="6677",
-        guild_id="5566",
-        author=User(id="3344"),
-        content="test direct message create event",
-    )
+    content = "test direct message create event"
+    msg_id = "1235"
+    event = fake_direct_message_create_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -85,21 +123,14 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime(2023, 7, 30, 0, 0, 0, 0, tzinfo=timezone.utc),
         "message",
-        "1235",
-        serialize_message(bot, Message("test direct message create event")),
-        "test direct message create event",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
-    event = GroupAtMessageCreateEvent(
-        __type__=EventType.GROUP_AT_MESSAGE_CREATE,
-        id="1236",
-        timestamp="2023-11-06T13:37:18+08:00",
-        group_openid="195747FDF0D845E98CF3886C5C7ED328",
-        author=GroupMemberAuthor(
-            id="3344", member_openid="8BE608110EAA4328A1883DEF239F5580"
-        ),
-        content="test group at message create event",
-    )
+    content = "test group at message create event"
+    msg_id = "1236"
+    event = fake_group_at_message_create_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -111,18 +142,14 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromisoformat("2023-11-06T13:37:18+08:00"),
         "message",
-        "1236",
-        serialize_message(bot, Message("test group at message create event")),
-        "test group at message create event",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
-    event = C2CMessageCreateEvent(
-        __type__=EventType.C2C_MESSAGE_CREATE,
-        id="1237",
-        timestamp="2023-11-06T13:37:18+08:00",
-        author=FriendAuthor(id="3344", user_openid="451368C569A1401D87172E9435EE8663"),
-        content="test c2c message create event",
-    )
+    content = "test c2c message create event"
+    msg_id = "1237"
+    event = fake_c2c_message_create_event(content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -134,9 +161,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromisoformat("2023-11-06T13:37:18+08:00"),
         "message",
-        "1237",
-        serialize_message(bot, Message("test c2c message create event")),
-        "test c2c message create event",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
 
@@ -147,9 +174,10 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
-            adapter=Adapter(get_driver()),
+            adapter=adapter,
             self_id="2233",
             bot_info=BotInfo(id="2233", token="", secret=""),
         )

--- a/tests/test_qq.py
+++ b/tests/test_qq.py
@@ -78,10 +78,21 @@ def fake_c2c_message_create_event(content: str, id: str) -> C2CMessageCreateEven
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.qq import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    msg = "test message create event"
+    msg_id = "1234"
+
+    direct_msg = "test direct message create event"
+    direct_msg_id = "1235"
+
+    group_at_msg = "test group at message create event"
+    group_at_msg_id = "1236"
+
+    c2c_msg = "test c2c message create event"
+    c2c_msg_id = "1237"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
@@ -90,10 +101,18 @@ async def test_record_recv_msg(app: App):
             bot_info=BotInfo(id="2233", token="", secret=""),
         )
 
-    content = "test message create event"
-    msg_id = "1234"
-    event = fake_message_create_event(content, msg_id)
-    await record_recv_msg(bot, event)
+        event = fake_message_create_event(msg, msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_direct_message_create_event(direct_msg, direct_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_group_at_message_create_event(group_at_msg, group_at_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_c2c_message_create_event(c2c_msg, c2c_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "QQ",
@@ -105,14 +124,10 @@ async def test_record_recv_msg(app: App):
         datetime(2023, 7, 30, 0, 0, 0, 0, tzinfo=timezone.utc),
         "message",
         msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        serialize_message(bot, Message(msg)),
+        msg,
     )
 
-    content = "test direct message create event"
-    msg_id = "1235"
-    event = fake_direct_message_create_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "QQ",
@@ -123,15 +138,11 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime(2023, 7, 30, 0, 0, 0, 0, tzinfo=timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        direct_msg_id,
+        serialize_message(bot, Message(direct_msg)),
+        direct_msg,
     )
 
-    content = "test group at message create event"
-    msg_id = "1236"
-    event = fake_group_at_message_create_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "QQ",
@@ -142,15 +153,11 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromisoformat("2023-11-06T13:37:18+08:00"),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        group_at_msg_id,
+        serialize_message(bot, Message(group_at_msg)),
+        group_at_msg,
     )
 
-    content = "test c2c message create event"
-    msg_id = "1237"
-    event = fake_c2c_message_create_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "QQ",
@@ -161,9 +168,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromisoformat("2023-11-06T13:37:18+08:00"),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        c2c_msg_id,
+        serialize_message(bot, Message(c2c_msg)),
+        c2c_msg,
     )
 
 

--- a/tests/test_red.py
+++ b/tests/test_red.py
@@ -135,10 +135,15 @@ async def fake_group_message_event(
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.red import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    private_msg = "test private message"
+    private_msg_id = "7272944767457625851"
+
+    group_msg = "test group message"
+    group_msg_id = "7272944513098472702"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
@@ -147,10 +152,12 @@ async def test_record_recv_msg(app: App):
             info=BotInfo(port=1234, token="1234"),
         )
 
-    content = "test private message"
-    msg_id = "7272944767457625851"
-    event = await fake_private_message_event(bot, content, msg_id)
-    await record_recv_msg(bot, event)
+        event = await fake_private_message_event(bot, private_msg, private_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = await fake_group_message_event(bot, group_msg, group_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "RedProtocol",
@@ -161,15 +168,11 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(1693364414, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        private_msg_id,
+        serialize_message(bot, Message(private_msg)),
+        private_msg,
     )
 
-    content = "test group message"
-    msg_id = "7272944513098472702"
-    event = await fake_group_message_event(bot, content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "RedProtocol",
@@ -180,9 +183,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(1693364354, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        group_msg_id,
+        serialize_message(bot, Message(group_msg)),
+        group_msg,
     )
 
 

--- a/tests/test_red.py
+++ b/tests/test_red.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from nonebot import get_driver
-from nonebot.adapters.red import Bot, Message
+from nonebot.adapters.red import Adapter, Bot, Message
 from nonebot.adapters.red.api.model import ChatType, Element, MsgType, RoleInfo
 from nonebot.adapters.red.config import BotInfo
 from nonebot.adapters.red.event import GroupMessageEvent, PrivateMessageEvent
@@ -11,27 +11,16 @@ from nonebug.app import App
 from .utils import check_record
 
 
-async def test_record_recv_msg(app: App):
-    """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.red import record_recv_msg
-    from nonebot_plugin_chatrecorder.message import serialize_message
-
-    async with app.test_api() as ctx:
-        bot = ctx.create_bot(
-            base=Bot,
-            adapter=get_driver()._adapters["RedProtocol"],
-            self_id="2233",
-            info=BotInfo(port=1234, token="1234"),
-        )
-    assert isinstance(bot, Bot)
-
-    message = Message("test private message")
+async def fake_private_message_event(
+    bot: Bot, content: str, msg_id: str
+) -> PrivateMessageEvent:
+    message = Message(content)
     elements_dict = await message.export(bot)
     elements = [type_validate_python(Element, element) for element in elements_dict]
-    event = PrivateMessageEvent(
+    return PrivateMessageEvent(
         message=message,
         original_message=message,
-        msgId="7272944767457625851",
+        msgId=msg_id,
         msgRandom="196942265",
         msgSeq="103",
         cntSeq="0",
@@ -81,31 +70,20 @@ async def test_record_recv_msg(app: App):
         nameType=0,
         avatarFlag=0,
     )
-    await record_recv_msg(bot, event)
-    await check_record(
-        "2233",
-        "RedProtocol",
-        "qq",
-        1,
-        "1234",
-        None,
-        None,
-        datetime.fromtimestamp(1693364414, timezone.utc),
-        "message",
-        "7272944767457625851",
-        serialize_message(bot, message),
-        message.extract_plain_text(),
-    )
 
-    message = Message("test group message")
+
+async def fake_group_message_event(
+    bot: Bot, content: str, msg_id: str
+) -> GroupMessageEvent:
+    message = Message(content)
     elements_dict = await message.export(bot)
     elements = [type_validate_python(Element, element) for element in elements_dict]
-    event = GroupMessageEvent(
+    return GroupMessageEvent(
         message=message,
         original_message=message,
-        msgId="7272944513098472702",
-        msgRandom="1526531828",
-        msgSeq="831",
+        msgId=msg_id,
+        msgRandom="196942265",
+        msgSeq="103",
         cntSeq="0",
         chatType=ChatType.GROUP,
         msgType=MsgType.normal,
@@ -124,7 +102,7 @@ async def test_record_recv_msg(app: App):
         msgMeta="0x",
         sendStatus=2,
         sendMemberName="",
-        sendNickName="uy/sun",
+        sendNickName="",
         guildName="",
         channelName="",
         elements=elements,
@@ -133,7 +111,7 @@ async def test_record_recv_msg(app: App):
         commentCnt="0",
         directMsgFlag=0,
         directMsgMembers=[],
-        peerName="uy/sun",
+        peerName="",
         editable=False,
         avatarMeta="",
         avatarPendant="",
@@ -142,17 +120,55 @@ async def test_record_recv_msg(app: App):
         timeStamp="0",
         isImportMsg=False,
         atType=0,
-        roleType=None,
+        roleType=0,
         fromChannelRoleInfo=RoleInfo(roleId="0", name="", color=0),
         fromGuildRoleInfo=RoleInfo(roleId="0", name="", color=0),
         levelRoleInfo=RoleInfo(roleId="0", name="", color=0),
         recallTime="0",
         isOnlineMsg=True,
         generalFlags="0x",
-        clientSeq="0",
+        clientSeq="27516",
         nameType=0,
         avatarFlag=0,
     )
+
+
+async def test_record_recv_msg(app: App):
+    """测试记录收到的消息"""
+    from nonebot_plugin_chatrecorder.adapters.red import record_recv_msg
+    from nonebot_plugin_chatrecorder.message import serialize_message
+
+    async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(
+            base=Bot,
+            adapter=adapter,
+            self_id="2233",
+            info=BotInfo(port=1234, token="1234"),
+        )
+
+    content = "test private message"
+    msg_id = "7272944767457625851"
+    event = await fake_private_message_event(bot, content, msg_id)
+    await record_recv_msg(bot, event)
+    await check_record(
+        "2233",
+        "RedProtocol",
+        "qq",
+        1,
+        "1234",
+        None,
+        None,
+        datetime.fromtimestamp(1693364414, timezone.utc),
+        "message",
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
+    )
+
+    content = "test group message"
+    msg_id = "7272944513098472702"
+    event = await fake_group_message_event(bot, content, msg_id)
     await record_recv_msg(bot, event)
     await check_record(
         "2233",
@@ -164,9 +180,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(1693364354, timezone.utc),
         "message",
-        "7272944513098472702",
-        serialize_message(bot, message),
-        message.extract_plain_text(),
+        msg_id,
+        serialize_message(bot, Message(content)),
+        content,
     )
 
 
@@ -176,13 +192,13 @@ async def test_record_send_msg(app: App):
     from nonebot_plugin_chatrecorder.message import serialize_message
 
     async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
-            adapter=get_driver()._adapters["RedProtocol"],
+            adapter=adapter,
             self_id="2233",
             info=BotInfo(port=1234, token="1234"),
         )
-    assert isinstance(bot, Bot)
 
     message = Message("test call_api send_message private message")
     elements = await message.export(bot)

--- a/tests/test_satori.py
+++ b/tests/test_satori.py
@@ -67,10 +67,15 @@ def fake_private_message_created_event(
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.satori import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    public_msg = "test public message created"
+    public_msg_id = "56163f81-de30-4c39-b4c4-3a205d0be9da"
+
+    private_msg = "test private message created"
+    private_msg_id = "56163f81-de30-4c39-b4c4-3a205d0be9db"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
@@ -89,10 +94,12 @@ async def test_record_recv_msg(app: App):
             info=ClientInfo(port=5140),
         )
 
-    content = "test public message created"
-    msg_id = "56163f81-de30-4c39-b4c4-3a205d0be9da"
-    event = fake_public_message_created_event(content, msg_id)
-    await record_recv_msg(bot, event)
+        event = fake_public_message_created_event(public_msg, public_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_private_message_created_event(private_msg, private_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "Satori",
@@ -103,15 +110,11 @@ async def test_record_recv_msg(app: App):
         "5566",
         datetime.fromtimestamp(17000000000 / 1000, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        public_msg_id,
+        serialize_message(bot, Message(public_msg)),
+        public_msg,
     )
 
-    content = "test private message created"
-    msg_id = "56163f81-de30-4c39-b4c4-3a205d0be9db"
-    event = fake_private_message_created_event(content, msg_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "Satori",
@@ -122,9 +125,9 @@ async def test_record_recv_msg(app: App):
         None,
         datetime.fromtimestamp(17000000000 / 1000, timezone.utc),
         "message",
-        msg_id,
-        serialize_message(bot, Message(content)),
-        content,
+        private_msg_id,
+        serialize_message(bot, Message(private_msg)),
+        private_msg,
     )
 
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -72,10 +72,18 @@ def fake_forum_topic_message_event(
 
 async def test_record_recv_msg(app: App):
     """测试记录收到的消息"""
-    from nonebot_plugin_chatrecorder.adapters.telegram import record_recv_msg
     from nonebot_plugin_chatrecorder.message import serialize_message
 
-    async with app.test_api() as ctx:
+    private_msg = "test private message"
+    private_msg_id = "1234"
+
+    group_msg = "test group message"
+    group_msg_id = "1235"
+
+    forum_msg = "test forum topic message"
+    forum_msg_id = "1236"
+
+    async with app.test_matcher() as ctx:
         adapter = get_driver()._adapters[Adapter.get_name()]
         bot = ctx.create_bot(
             base=Bot,
@@ -84,10 +92,15 @@ async def test_record_recv_msg(app: App):
             config=BotConfig(token="2233:xxx"),
         )
 
-    text = "test private message"
-    message_id = "1234"
-    event = fake_private_message_event(text, message_id)
-    await record_recv_msg(bot, event)
+        event = fake_private_message_event(private_msg, private_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_group_message_event(group_msg, group_msg_id)
+        ctx.receive_event(bot, event)
+
+        event = fake_forum_topic_message_event(forum_msg, forum_msg_id)
+        ctx.receive_event(bot, event)
+
     await check_record(
         "2233",
         "Telegram",
@@ -99,14 +112,10 @@ async def test_record_recv_msg(app: App):
         datetime.fromtimestamp(1122, timezone.utc),
         "message",
         "3344_1234",
-        serialize_message(bot, Message(text)),
-        text,
+        serialize_message(bot, Message(private_msg)),
+        private_msg,
     )
 
-    text = "test group message"
-    message_id = "1235"
-    event = fake_group_message_event(text, message_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "Telegram",
@@ -118,14 +127,10 @@ async def test_record_recv_msg(app: App):
         datetime.fromtimestamp(1122, timezone.utc),
         "message",
         "5566_1235",
-        serialize_message(bot, Message(text)),
-        text,
+        serialize_message(bot, Message(group_msg)),
+        group_msg,
     )
 
-    text = "test forum topic message"
-    message_id = "1236"
-    event = fake_forum_topic_message_event(text, message_id)
-    await record_recv_msg(bot, event)
     await check_record(
         "2233",
         "Telegram",
@@ -137,8 +142,8 @@ async def test_record_recv_msg(app: App):
         datetime.fromtimestamp(1122, timezone.utc),
         "message",
         "5566_1236",
-        serialize_message(bot, Message(text)),
-        text,
+        serialize_message(bot, Message(forum_msg)),
+        forum_msg,
     )
 
 


### PR DESCRIPTION
测试收到的消息时使用 `ctx.receive_event`，而不是直接调用函数
这样可以测试 `event_postprocessor` 中的依赖注入