### PR TITLE
fix: serialize nested messages in OneBot v11 forward nodes

### DIFF
--- a/nonebot_plugin_chatrecorder/adapters/onebot_v11.py
+++ b/nonebot_plugin_chatrecorder/adapters/onebot_v11.py
@@ -139,7 +139,19 @@ try:
         @override
         def serialize(cls, msg: Message) -> JsonMsg:
             cache_b64_msg(msg)
-            return super().serialize(msg)
+            return [
+                {"type": seg.type, "data": cls._serialize_data(seg.data)}
+                for seg in msg
+            ]
+
+        @classmethod
+        def _serialize_data(cls, data: dict) -> dict:
+            # 合并转发消息的 node 段中嵌套着 Message 对象，
+            # 直接存储会导致 json 序列化失败
+            return {
+                k: cls.serialize(v) if isinstance(v, Message) else v
+                for k, v in data.items()
+            }
 
     class Deserializer(MessageDeserializer[Message]):
         @classmethod

--- a/nonebot_plugin_chatrecorder/adapters/onebot_v11.py
+++ b/nonebot_plugin_chatrecorder/adapters/onebot_v11.py
@@ -140,8 +140,7 @@ try:
         def serialize(cls, msg: Message) -> JsonMsg:
             cache_b64_msg(msg)
             return [
-                {"type": seg.type, "data": cls._serialize_data(seg.data)}
-                for seg in msg
+                {"type": seg.type, "data": cls._serialize_data(seg.data)} for seg in msg
             ]
 
         @classmethod

--- a/tests/test_onebot_v11.py
+++ b/tests/test_onebot_v11.py
@@ -219,3 +219,43 @@ async def test_record_send_msg(app: App):
         serialize_message(bot, message),
         message.extract_plain_text(),
     )
+
+
+async def test_record_send_forward_msg(app: App):
+    """测试记录合并转发消息"""
+    from nonebot.adapters.onebot.v11 import MessageSegment
+    from nonebot_plugin_uninfo import Scene, SceneType, Session, User
+
+    from nonebot_plugin_chatrecorder.adapters.onebot_v11 import record_send_msg
+    from nonebot_plugin_chatrecorder.message import serialize_message
+
+    async with app.test_api() as ctx:
+        adapter = get_driver()._adapters[Adapter.get_name()]
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="11")
+
+    group_id = 654321
+    message_id = 11451466666
+    message = Message(
+        MessageSegment.node_custom(10, "test", Message("test forward message"))
+    )
+    await record_send_msg(
+        bot,
+        None,
+        "send_group_msg",
+        {"group_id": group_id, "message": message},
+        {"message_id": message_id},
+    )
+    await check_record(
+        Session(
+            self_id="11",
+            adapter="OneBot V11",
+            scope="QQClient",
+            scene=Scene(id=str(group_id), type=SceneType.GROUP),
+            user=User(id="11"),
+        ),
+        None,
+        "message_sent",
+        str(message_id),
+        serialize_message(bot, message),
+        message.extract_plain_text(),
+    )


### PR DESCRIPTION
Fixes #74. A node_custom segment carries a nested Message in seg.data['content'], and the default `seg.__dict__` serialization leaves those MessageSegment objects as-is, so the CalledAPI hook fails at the sqlalchemy json serializer when recording a sent forward message. The v11 Serializer now converts nested Message values in segment data recursively; added a test that records a forward message end to end.